### PR TITLE
unterstrich ist kein minus

### DIFF
--- a/site.yaml
+++ b/site.yaml
@@ -255,7 +255,7 @@
 
     - name: add de-gendered DU german language file
       copy:
-        src: "files/de-cool.json"
+        src: "files/de_cool.json"
         dest: "{{item}}"
         backup: true
       loop:


### PR DESCRIPTION
Die datei in files ist de_cool, in der site.yaml war es de-cool.
ansible hat dann korrekter weise rumgemeckert.